### PR TITLE
Enabling PWA Capabilities

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -5,8 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>changelog Clone</title>
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
-    <script src="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.js"></script>
     <link rel="manifest" href="manifest.json" />
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/serviceWorker.js').then(registration => {
+            console.log('ServiceWorker registration successful with scope: ', registration.scope);
+          }, err => {
+            console.log('ServiceWorker registration failed: ', err);
+          });
+        });
+      }
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.js"></script>
     <style>
       body {
         font-family: "Fira Code", Arial, sans-serif !important;
@@ -156,15 +167,6 @@
     </div>
     <button id="save">Save to JSON</button>
     <script>
-      if ("worker" in navigator) {
-        window.addEventListener("load", () => {
-          navigator.serviceWorker
-          .register("/worker.js")
-          .then(res => console.log("Service worker registered"))
-          .catch(err => console.error("Service worker registration failed", err));
-        });
-      }
-
       let data = [];
       let currentId = 1; // Initialize the ID counter
 

--- a/changelog.html
+++ b/changelog.html
@@ -6,6 +6,7 @@
     <title>changelog Clone</title>
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <script src="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.js"></script>
+    <link rel="manifest" href="manifest.json" />
     <style>
       body {
         font-family: "Fira Code", Arial, sans-serif !important;
@@ -155,6 +156,15 @@
     </div>
     <button id="save">Save to JSON</button>
     <script>
+      if ("worker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker
+          .register("/worker.js")
+          .then(res => console.log("Service worker registered"))
+          .catch(err => console.error("Service worker registration failed", err));
+        });
+      }
+
       let data = [];
       let currentId = 1; // Initialize the ID counter
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,6 @@
+{
+    "name": "CHANGELOG",
+    "short_name": "changelog",
+    "start_url": "changelog.html",
+    "display": "standalone"
+}

--- a/manifest.json
+++ b/manifest.json
@@ -2,5 +2,14 @@
     "name": "CHANGELOG",
     "short_name": "changelog",
     "start_url": "changelog.html",
-    "display": "standalone"
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "theme_color": "#000000",
+    "icons": [
+        {
+            "src": "favicon.ico",
+            "sizes": "64x64 48x48 32x32 24x24 16x16",
+            "type": "image/x-icon"
+        }
+    ]
 }

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,24 +1,23 @@
-const staticChangeLog = "changelog-pwa-v1"
+const staticChangeLog = "changelog-pwa-v1";
 const assets = [
     "/",
     "/changelog.html",
     "/changelog.png",
-    "/favicon.ico",
-    "/changelog-data.json",
-]
+    "/favicon.ico"
+];
 
 self.addEventListener("install", installEvent => {
     installEvent.waitUntil(
         caches.open(staticChangeLog).then(cache => {
-            cache.addAll(assets)
+            cache.addAll(assets);
         })
-    )
-})
+    );
+});
 
 self.addEventListener("fetch", fetchEvent => {
     fetchEvent.respondWith(
         caches.match(fetchEvent.request).then(cacheResponse => {
-            return cacheResponse || fetch(fetchEvent.request)
+            return cacheResponse || fetch(fetchEvent.request);
         })
-    )
-})
+    );
+});

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,24 @@
+const staticChangeLog = "changelog-pwa-v1"
+const assets = [
+    "/",
+    "/changelog.html",
+    "/changelog.png",
+    "/favicon.ico",
+    "/changelog-data.json",
+]
+
+self.addEventListener("install", installEvent => {
+    installEvent.waitUntil(
+        caches.open(staticChangeLog).then(cache => {
+            cache.addAll(assets)
+        })
+    )
+})
+
+self.addEventListener("fetch", fetchEvent => {
+    fetchEvent.respondWith(
+        caches.match(fetchEvent.request).then(cacheResponse => {
+            return cacheResponse || fetch(fetchEvent.request)
+        })
+    )
+})


### PR DESCRIPTION
This pull request introduces changes to add Progressive Web App (PWA) capabilities to the `changelog.html` page. The most important changes include adding a service worker, creating a manifest file, and updating the HTML to register the service worker.

Enhancements for PWA capabilities:

* [`changelog.html`](diffhunk://#diff-748c691d2309ccc7592b7078dd5e055ba1295f8f5ba8df2fba66a720df7f63f5R8-R19): Added a link to the manifest file and a script to register the service worker.
* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743R1-R15): Created a new manifest file with necessary PWA metadata, including name, short name, start URL, display mode, background color, theme color, and icons.
* [`serviceWorker.js`](diffhunk://#diff-330734641ac7768c10c47bc947d7791c6bdb2649a84fe39b846a9d124cb9ca77R1-R23): Added a new service worker script to cache assets and handle fetch events for offline support.